### PR TITLE
Set version of vtk dependency

### DIFF
--- a/jpsvis.rb
+++ b/jpsvis.rb
@@ -8,7 +8,7 @@ class Jpsvis < Formula
 
   depends_on "cmake" => :build
   depends_on "qt"
-  depends_on "vtk"
+  depends_on "vtk@8.2"
 
   def install
     Dir.mkdir "build"


### PR DESCRIPTION
VTK 9 breaks the building process at the moment, needs to be set to 8.2 to enable building again.